### PR TITLE
docs(sample): remove protobuf feature from native image sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ If you are using Maven, add this to your pom.xml file:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-tasks</artifactId>
-  <version>2.1.9</version>
+  <version>2.1.10</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-tasks:2.1.9'
+implementation 'com.google.cloud:google-cloud-tasks:2.1.10'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-tasks" % "2.1.9"
+libraryDependencies += "com.google.cloud" % "google-cloud-tasks" % "2.1.10"
 ```
 
 ## Authentication

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -121,8 +121,6 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
-                <buildArg>--initialize-at-build-time</buildArg>
-                <buildArg>--features=com.google.cloud.nativeimage.features.ProtobufMessageFeature</buildArg>
               </buildArgs>
             </configuration>
             <executions>


### PR DESCRIPTION
The ProtobufMessageFeature will automatically be brought in after https://github.com/googleapis/gax-java/pull/1641 is merged and released. Merge after PR 1641 is released.
